### PR TITLE
Fix typo in doc block for redirectAction

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -50,7 +50,7 @@ class RedirectController
      * @param string     $route             The route name to redirect to
      * @param bool       $permanent         Whether the redirection is permanent
      * @param bool|array $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
-     * @param bool       $keepRequestMethod Wheter redirect action should keep HTTP request method
+     * @param bool       $keepRequestMethod Whether redirect action should keep HTTP request method
      *
      * @throws HttpException In case the route name is empty
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fixes a typo in the doc block for RedirectController:redirectAction()